### PR TITLE
Export graph files to godot filesystem

### DIFF
--- a/GDMP/framework/BUILD
+++ b/GDMP/framework/BUILD
@@ -7,7 +7,6 @@ cc_library(
         ":packet",
         "//mediapipe/framework:calculator_graph",
         "//mediapipe/framework:packet",
-        "//mediapipe/framework/port:file_helpers",
         "//mediapipe/framework/port:parse_text_proto",
         "//mediapipe/framework/port:status",
         "//third_party:godot",

--- a/GDMP/framework/graph.h
+++ b/GDMP/framework/graph.h
@@ -27,7 +27,7 @@ class Graph : public Reference {
 
 		void _init();
 
-		void initialize(String graph_path);
+		void initialize(String graph_path, bool as_text);
 		void add_packet_callback(String stream_name, Object *object, String method);
 		void start(Dictionary side_packets);
 		void add_packet(String stream_name, Ref<Packet> packet);

--- a/GDMP/gdmp.cc
+++ b/GDMP/gdmp.cc
@@ -45,7 +45,7 @@ void GDMP::_on_new_gpu_frame(String stream_name, Ref<Packet> packet) {
 void GDMP::init_graph(String graph_path) {
 	close_camera();
 	graph = Ref<Graph>(Graph::_new());
-	graph->initialize(graph_path);
+	graph->initialize(graph_path, true);
 #if !MEDIAPIPE_DISABLE_GPU
 	gpu_helper = graph->get_gpu_helper();
 #endif

--- a/README.md
+++ b/README.md
@@ -54,9 +54,9 @@ GDMP is a plugin for Godot 3.3+ that allows utilizing MediaPipe graphs in GDScri
         "Android":
             GDMP.init_graph("name_of_your_graph.binarypb")
         "X11":
-            GDMP.init_graph("path/to/your/graph.pbtxt")
+            GDMP.init_graph("res://path/to/your/graph.pbtxt")
     ```
-    Note that for desktop Linux, files used by MediaPipe need to be placed externally (e.g. place the models in your project's directory according to the calculator's model_path, and export graphs and models outside of .pck file)
+    Note that for desktop Linux, files used by MediaPipe graphs need to be placed externally (e.g. place the models in your project's directory according to the calculator's model_path, and export models outside of .pck file)
 3. To add a proto callback to the graph's output stream:
 
     ```gdscript

--- a/addons/GDMP/editor/exporter.gd
+++ b/addons/GDMP/editor/exporter.gd
@@ -1,0 +1,33 @@
+extends EditorExportPlugin
+
+func _export_begin(features : PoolStringArray, is_debug : bool, path : String, flags : int) -> void:
+	var exports : PoolStringArray = find_files("res://", ["binarypb", "pbtxt"])
+	for file in exports:
+		var f : File = File.new()
+		var result : int = f.open(file, File.READ)
+		if result != OK:
+			printerr("GDMP exporter: Failed to read %s: %d" % [file, result])
+			continue
+		add_file(file, f.get_buffer(f.get_len()), false)
+
+func find_files(path : String, extenstions : PoolStringArray) -> PoolStringArray:
+	var files : PoolStringArray = []
+	var dir : Directory = Directory.new()
+	var result : int = dir.open(path)
+	if result != OK:
+		printerr("GDMP exporter: Failed to open %s: %d" % [path, result])
+	else:
+		dir.list_dir_begin(true, true)
+		var filename : String
+		while true:
+			filename = dir.get_next()
+			if filename.empty():
+				break
+			var next : String = "%s%s" if path.ends_with("/") else "%s/%s"
+			next = next % [path, filename]
+			if dir.dir_exists(filename) and not next == "res://android":
+				files.append_array(find_files(next, extenstions))
+			elif filename.get_extension() in extenstions:
+				files.append(next)
+		dir.list_dir_end()
+	return files

--- a/addons/GDMP/plugin.gd
+++ b/addons/GDMP/plugin.gd
@@ -1,8 +1,12 @@
 tool
 extends EditorPlugin
 
+var exporter : EditorExportPlugin = preload("res://addons/GDMP/editor/exporter.gd").new()
+
 func _enter_tree():
 	add_autoload_singleton("GDMP", "res://addons/GDMP/GDMP.gd")
+	add_export_plugin(exporter)
 
 func _exit_tree():
 	remove_autoload_singleton("GDMP")
+	remove_export_plugin(exporter)


### PR DESCRIPTION
The goal of this PR is to make loading graph files take place in Godot's filesystem, without placing them outside of .pck file, thus making the graph initialization more portable.
- Adds a `EditorExportPlugin` that add *.pbtxt and *.binarypb when exporting project.
- In GDNative Graph::initialize, use Godot's `File` class to read graph files, therefore removal of `//mediapipe/framework/port:file_helpers` dependency.

Other assets used by Mediapipe graphs like tflite models still need to be placed outside .pck file though, which seems to be related to `resource_util.h` in Mediapipe source code if we want to change this behavior.

Android platform isn't affected by this change since the difference between GDNative and Java implementation, if we were able to migrate Android code to GDNative, the way to initialize a graph can then be unified.