### PR TITLE
Merge mediapipe and GDMP aar build process

### DIFF
--- a/GDMP/mediapipe_aar/java/com/google/mediapipe/BUILD
+++ b/GDMP/mediapipe_aar/java/com/google/mediapipe/BUILD
@@ -1,8 +1,0 @@
-load("//mediapipe/java/com/google/mediapipe:mediapipe_aar.bzl", "mediapipe_aar")
-
-mediapipe_aar(
-    name = "mediapipe_aar",
-    calculators = [
-        "@XNNPACK//:xnnpack_for_tflite",
-    ],
-)

--- a/README.md
+++ b/README.md
@@ -12,25 +12,21 @@ GDMP is a plugin for Godot 3.3+ that allows utilizing MediaPipe graphs in GDScri
 ## Building for Android
 1. Refer to [Prerequisite](https://google.github.io/mediapipe/getting_started/android.html#prerequisite) section for Java and Android SDK & NDK setup.
 2. Place the calculator dependencies in `GDMP/variables.bzl`
-3. Run:
+3. Copy or symlink godot-lib to `android/GDMP/libs` directory as dependency, and rename the file to `godot-lib.release.aar`.
 
-    ```
-    build.py aar
-    ```
-    to build mediapipe_aar, generated file will be located in
+    godot-lib can be obtained from [godotengine.org](https://godotengine.org/download) or from your project's `android/build/libs/release` if Android build template is installed.
 
-    `mediapipe/bazel-bin/mediapipe/GDMP/mediapipe_aar/java/com/google/mediapipe/mediapipe_aar.aar`
-4. Copy or link godot-lib and mediapipe_aar AAR to `android/GDMP/libs` directory.
-5. Build GDMP AAR, copy generated file to your project's `android/plugins` directory, along with mediapipe_aar from step 3.
-6. Run:
+4. Build GDMP AAR using Android Studio or gradlew, copy the release variant AAR located in `android/GDMP/build/outputs/aar` to your project's `android/plugins` directory.
+5. Run:
 
     ```
     build.py android
     ```
     to build android library, and copy them to your project's `addons/GDMP/libs/android/{ABI}` depending on your target ABIs.
-    (Optional) also copy `libopencv_java3.so` to the project as GDNative library dependencies if OpenCV is used in calculators.
 
-7. Copy `plugins/GDMP.gdap` to your project's `android/plugins` directory.
+    (Optional) also copy `libopencv_java3.so` to the project and add it as GDNative library dependencies if OpenCV is used in calculators.
+
+6. Copy `plugins/GDMP.gdap` to your project's `android/plugins` directory.
 
     Files used by MediaPipe graphs (e.g. TFLite models) need to be placed in your project's directory according to the path provided by the calculator configs.
 

--- a/android/GDMP/build.gradle
+++ b/android/GDMP/build.gradle
@@ -30,13 +30,9 @@ dependencies {
     implementation fileTree(dir: "libs", include: ["*.jar"])
     implementation 'androidx.appcompat:appcompat:1.2.0'
     compileOnly files('libs/godot-lib.release.aar')
-    compileOnly files('libs/mediapipe_aar.aar')
-     // MediaPipe deps
+    // MediaPipe deps
     implementation 'com.google.flogger:flogger:0.3.1'
     implementation 'com.google.flogger:flogger-system-backend:0.3.1'
-    implementation 'com.google.code.findbugs:jsr305:3.0.2'
-    implementation 'com.google.guava:guava:27.0.1-android'
-    implementation 'com.google.protobuf:protobuf-java:3.11.4'
     // CameraX core library
     def camerax_version = "1.0.0-beta10"
     implementation "androidx.camera:camera-core:$camerax_version"

--- a/android/GDMP/libs/.gitignore
+++ b/android/GDMP/libs/.gitignore
@@ -1,2 +1,1 @@
 godot-lib.release.aar
-mediapipe_aar.aar

--- a/android/GDMP/src/main/java/com/google/mediapipe/components/CameraHelper.java
+++ b/android/GDMP/src/main/java/com/google/mediapipe/components/CameraHelper.java
@@ -1,0 +1,1 @@
+../../../../../../../../../mediapipe/mediapipe/java/com/google/mediapipe/components/CameraHelper.java

--- a/android/GDMP/src/main/java/com/google/mediapipe/components/CameraXPreviewHelper.java
+++ b/android/GDMP/src/main/java/com/google/mediapipe/components/CameraXPreviewHelper.java
@@ -1,0 +1,1 @@
+../../../../../../../../../mediapipe/mediapipe/java/com/google/mediapipe/components/CameraXPreviewHelper.java

--- a/android/GDMP/src/main/java/com/google/mediapipe/components/ExternalTextureConverter.java
+++ b/android/GDMP/src/main/java/com/google/mediapipe/components/ExternalTextureConverter.java
@@ -1,0 +1,1 @@
+../../../../../../../../../mediapipe/mediapipe/java/com/google/mediapipe/components/ExternalTextureConverter.java

--- a/android/GDMP/src/main/java/com/google/mediapipe/components/PermissionHelper.java
+++ b/android/GDMP/src/main/java/com/google/mediapipe/components/PermissionHelper.java
@@ -1,0 +1,1 @@
+../../../../../../../../../mediapipe/mediapipe/java/com/google/mediapipe/components/PermissionHelper.java

--- a/android/GDMP/src/main/java/com/google/mediapipe/components/TextureFrameConsumer.java
+++ b/android/GDMP/src/main/java/com/google/mediapipe/components/TextureFrameConsumer.java
@@ -1,0 +1,1 @@
+../../../../../../../../../mediapipe/mediapipe/java/com/google/mediapipe/components/TextureFrameConsumer.java

--- a/android/GDMP/src/main/java/com/google/mediapipe/components/TextureFrameProducer.java
+++ b/android/GDMP/src/main/java/com/google/mediapipe/components/TextureFrameProducer.java
@@ -1,0 +1,1 @@
+../../../../../../../../../mediapipe/mediapipe/java/com/google/mediapipe/components/TextureFrameProducer.java

--- a/android/GDMP/src/main/java/com/google/mediapipe/framework/AppTextureFrame.java
+++ b/android/GDMP/src/main/java/com/google/mediapipe/framework/AppTextureFrame.java
@@ -1,0 +1,1 @@
+../../../../../../../../../mediapipe/mediapipe/java/com/google/mediapipe/framework/AppTextureFrame.java

--- a/android/GDMP/src/main/java/com/google/mediapipe/framework/Compat.java
+++ b/android/GDMP/src/main/java/com/google/mediapipe/framework/Compat.java
@@ -1,0 +1,1 @@
+../../../../../../../../../mediapipe/mediapipe/java/com/google/mediapipe/framework/Compat.java

--- a/android/GDMP/src/main/java/com/google/mediapipe/framework/GlSyncToken.java
+++ b/android/GDMP/src/main/java/com/google/mediapipe/framework/GlSyncToken.java
@@ -1,0 +1,1 @@
+../../../../../../../../../mediapipe/mediapipe/java/com/google/mediapipe/framework/GlSyncToken.java

--- a/android/GDMP/src/main/java/com/google/mediapipe/framework/TextureFrame.java
+++ b/android/GDMP/src/main/java/com/google/mediapipe/framework/TextureFrame.java
@@ -1,0 +1,1 @@
+../../../../../../../../../mediapipe/mediapipe/java/com/google/mediapipe/framework/TextureFrame.java

--- a/android/GDMP/src/main/java/com/google/mediapipe/framework/TextureReleaseCallback.java
+++ b/android/GDMP/src/main/java/com/google/mediapipe/framework/TextureReleaseCallback.java
@@ -1,0 +1,1 @@
+../../../../../../../../../mediapipe/mediapipe/java/com/google/mediapipe/framework/TextureReleaseCallback.java

--- a/android/GDMP/src/main/java/com/google/mediapipe/glutil
+++ b/android/GDMP/src/main/java/com/google/mediapipe/glutil
@@ -1,0 +1,1 @@
+../../../../../../../../mediapipe/mediapipe/java/com/google/mediapipe/glutil

--- a/android/GDMP/src/main/java/org/godotengine/gdmp/GDMP.java
+++ b/android/GDMP/src/main/java/org/godotengine/gdmp/GDMP.java
@@ -15,7 +15,6 @@ public class GDMP extends GodotPlugin {
     private Godot godot;
 
     static {
-        System.loadLibrary("mediapipe_jni");
         System.loadLibrary("gdmp");
     }
 

--- a/android/GDMP/src/main/java/org/godotengine/gdmp/GDMPCameraHelper.java
+++ b/android/GDMP/src/main/java/org/godotengine/gdmp/GDMPCameraHelper.java
@@ -10,9 +10,7 @@ import com.google.mediapipe.components.CameraHelper.OnCameraStartedListener;
 import com.google.mediapipe.components.CameraXPreviewHelper;
 import com.google.mediapipe.components.ExternalTextureConverter;
 import com.google.mediapipe.components.TextureFrameConsumer;
-import com.google.mediapipe.framework.GraphGlSyncToken;
 import com.google.mediapipe.framework.TextureFrame;
-import com.google.mediapipe.framework.TextureReleaseCallback;
 import com.google.mediapipe.glutil.EglManager;
 
 public class GDMPCameraHelper extends CameraXPreviewHelper implements OnCameraStartedListener, TextureFrameConsumer {
@@ -55,10 +53,6 @@ public class GDMPCameraHelper extends CameraXPreviewHelper implements OnCameraSt
         if(converter != null) {
             converter.close();
         }
-    }
-
-    public void releaseFrame(TextureReleaseCallback frame, long syncToken) {
-        frame.release(new GraphGlSyncToken(syncToken));
     }
 
     public native void nativeOnNewFrame(long nativeCallerPtr, TextureFrame frame, int name, int width, int height);

--- a/build.py
+++ b/build.py
@@ -27,13 +27,6 @@ try:
             '--cpu=arm64-v8a', \
             '--copt', '-fPIC', \
             '//mediapipe/GDMP:gdmp'])
-    elif args.target.lower() == 'aar':
-        bazel_args.extend([\
-            '--host_crosstool_top=@bazel_tools//tools/cpp:toolchain', \
-            '--define', 'EXCLUDE_OPENCV_SO_LIB=1', \
-            '--fat_apk_cpu=arm64-v8a', \
-            '--linkopt=-s', \
-            '//mediapipe/GDMP/mediapipe_aar/java/com/google/mediapipe:mediapipe_aar'])
     elif args.target.lower() == 'desktop':
         bazel_args.extend([\
             '--copt', '-fPIC', \

--- a/plugins/GDMP.gdap
+++ b/plugins/GDMP.gdap
@@ -6,6 +6,5 @@ binary="GDMP-release.aar"
 
 [dependencies]
 
-local=["mediapipe_aar.aar"]
-remote=["androidx.appcompat:appcompat:1.2.0", "com.google.flogger:flogger:0.3.1", "com.google.flogger:flogger-system-backend:0.3.1", "com.google.code.findbugs:jsr305:3.0.2", "com.google.guava:guava:27.0.1-android", "com.google.guava:guava:27.0.1-android", "com.google.protobuf:protobuf-java:3.11.4", "androidx.camera:camera-core:1.0.0-beta10", "androidx.camera:camera-camera2:1.0.0-beta10", "androidx.camera:camera-lifecycle:1.0.0-beta10"]
+remote=["androidx.appcompat:appcompat:1.2.0", "com.google.flogger:flogger:0.3.1", "com.google.flogger:flogger-system-backend:0.3.1", "androidx.camera:camera-core:1.0.0-beta10", "androidx.camera:camera-camera2:1.0.0-beta10", "androidx.camera:camera-lifecycle:1.0.0-beta10"]
 custom_maven_repos=[]


### PR DESCRIPTION
This PR will merge the process of building Mediapipe and GDMP aar into one step, by partially symlink Mediapipe Java source code we need to GDMP Android plugin directory for building them altogether.

This will also reduce exported Android project size by a bit since the removal of unnecessary java dependencies and mediapipe_jni library(and providing JNI functions we actually need ourselves).