### PR TITLE
Streamline the setup process (mostly for Windows)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+extension_api.json
+venv/

--- a/README.md
+++ b/README.md
@@ -9,17 +9,16 @@ GDMP is a Godot 3.3+ plugin for utilizing MediaPipe graphs in GDScript.
 
     `git submodule update --init --recursive`
 2. Install [Bazelisk](https://bazel.build/install/bazelisk) or Bazel version that meets MediaPipe requirement.
-3. Follow [Godot documentation](https://docs.godotengine.org/en/stable/tutorials/scripting/gdextension/gdextension_cpp_example.html#building-the-c-bindings) to generate `extension_api.json` for your Godot version, then go to `godot-cpp` directory and run:
+3. Run `setup.py` to generate the [godot-cpp](https://github.com/godotengine/godot-cpp) bindings as well as apply/setup source code to the `mediapipe` workspace. Run `setup.py --help` to view the various options.
 
-    ```
-    python -c "from binding_generator import *; generate_bindings('/path/to/your/extension_api.json', True)"
-    ```
+Example:
+```
+./setup.py --godot-binary path/to/godot/binary
+```
 
-    to generate Godot C++ bindings directly, replacing `/path/to/your/extension_api.json` with the path to your `extension_api.json`
-4. Run `setup.py`, the script will apply necessary changes and setup source code to `mediapipe` workspace.
-5. Add calculator dependencies in `GDMP/GDMP.bzl`
-6. Copy `addons` to your Godot project's root directory.
-7. (Recommended) Set `GODOT_PROJECT` environment variable that points to your Godot project, the build script will try to automate copy process if it is detected.
+4. Add calculator dependencies in `GDMP/GDMP.bzl`
+5. Copy `addons` to your Godot project's root directory.
+6. (Recommended) Set `GODOT_PROJECT` environment variable that points to your Godot project, the build script will try to automate copy process if it is detected.
 
 ## Building for Android
 1. Refer to [Prerequisite](https://developers.google.com/mediapipe/framework/getting_started/android#prerequisite) section for Java and Android SDK & NDK setup.
@@ -64,7 +63,7 @@ GDMP is a Godot 3.3+ plugin for utilizing MediaPipe graphs in GDScript.
     Bash can be installed from [Git for Windows](https://gitforwindows.org) or [MSYS2](https://www.msys2.org)
 3. Install OpenCV and configure `mediapipe` workspace:
     - Modify `mediapipe/WORKSPACE` for `path` under `windows_opencv` if OpenCV is not installed on `C:\opencv`
-    - Modify `OPENCV_VERSION` in `mediapipe/thrid_party/opencv_windows.BUILD` if OpenCV version is not `3.4.10`
+    - Modify `OPENCV_VERSION` in `mediapipe/third_party/opencv_windows.BUILD` if OpenCV version is not `3.4.10`
 
     Refer to [MediaPipe documentation](https://developers.google.com/mediapipe/framework/getting_started/install#installing_on_windows) for more details.
 4. Run:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+autopep8==2.0.2
+numpy==1.24.3
+pycodestyle==2.10.0
+tomli==2.0.1

--- a/setup.py
+++ b/setup.py
@@ -1,38 +1,145 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 import sys
+import os
 from os import path, symlink, unlink
 from shutil import rmtree, which
 from subprocess import run
+import platform
+from argparse import ArgumentParser, Namespace
+from typing import Callable
+import venv
 
-mediapipe_dir = path.join(path.dirname(__file__), 'mediapipe')
+DEFAULT_OPENCV_VERSION = "3.4.10"
 
-# Patching mediapipe workspace
-mediapipe_setup = path.join(path.dirname(__file__), 'mediapipe_setup.diff')
-if which('git'):
-    print("Using git to patch mediapipe workspace.")
-    run(['git', 'apply', '--unsafe-paths',
-        '--directory='+mediapipe_dir, mediapipe_setup])
-elif which('patch'):
-    print("Using patch to patch mediapipe workspace.")
-    run(['patch', '-p1', '-d', mediapipe_dir, '-i', mediapipe_setup])
-else:
-    print("Error: 'git' or 'patch' cannot be found for patching mediapipe workspace.")
-    sys.exit(-1)
+current_platform = platform.system().lower()
+if current_platform == "windows":
+    MEDIAPIPE_WORKSPACE_PATH = "mediapipe/WORKSPACE"
+    DEFAULT_OPENCV_INSTALL_PATH_REPLACE = "path = \"C:\\\\opencv\\\\build\","
+    OPENCV_INSTALL_PATH_FORMAT = "path = \"{}\""
 
-# Symlink GDMP source code to mediapipe workspace
-src_dir = path.join(path.dirname(__file__), 'GDMP')
-dst_dir = path.join(mediapipe_dir, 'GDMP')
-if path.isdir(dst_dir):
-    try:
-        unlink(dst_dir)
-    except:
-        rmtree(dst_dir)
-try:
-    if sys.platform.startswith('win32'):
-        run('mklink /J "%s" "%s"' % (dst_dir, src_dir), check=True, shell=True)
+    OPENCV_BUILD_PATH = "mediapipe/third_party/opencv_windows.BUILD"
+    DEFAULT_OPENCV_VERSION_REPLACE = "OPENCV_VERSION = \"3410\""
+    OPENCV_VERSION_FORMAT = "OPENCV_VERSION = \"{}\""
+
+
+def generate_bindings(api_json_path: str) -> None:
+    # Could use a contextmanager but that feels like overkill
+    os.chdir("godot-cpp/")
+    sys.path.append(os.getcwd())
+
+    import binding_generator as bg
+    bg.generate_bindings(api_json_path, True)
+
+    sys.path.pop()
+    os.chdir("..")
+
+
+def patch_and_symlink(symlinker: Callable) -> None:
+    mediapipe_dir = path.join(path.dirname(__file__), 'mediapipe')
+
+    # Patching mediapipe workspace
+    mediapipe_setup = path.join(path.dirname(__file__), 'mediapipe_setup.diff')
+    if which('git'):
+        print("Using git to patch mediapipe workspace.")
+        run(['git', 'apply', '--unsafe-paths',
+             '--directory='+mediapipe_dir, mediapipe_setup])
+    elif which('patch'):
+        print("Using patch to patch mediapipe workspace.")
+        run(['patch', '-p1', '-d', mediapipe_dir, '-i', mediapipe_setup])
     else:
-        symlink(src_dir, dst_dir, True)
-except:
-    print("Error: Unable to symlink GDMP source to mediapipe workspace.")
-    sys.exit(-1)
+        print("Error: 'git' or 'patch' cannot be found for patching mediapipe workspace.")
+        sys.exit(-1)
+
+    # Symlink GDMP source code to mediapipe workspace
+    src_dir = path.join(path.dirname(__file__), 'GDMP')
+    dst_dir = path.join(mediapipe_dir, 'GDMP')
+    if path.isdir(dst_dir):
+        try:
+            unlink(dst_dir)
+        except:
+            rmtree(dst_dir)
+    try:
+        symlinker(src_dir, dst_dir)
+    except:
+        print("Error: Unable to symlink GDMP source to mediapipe workspace.")
+        sys.exit(-1)
+
+
+def modify_file(file_path: str, replace_str: str, format_str: str, replacement: str) -> None:
+    print("Modifying file {}".format(file_path))
+
+    # TODO could maybe use a raw string?
+    formatted_str: str = format_str.format(replacement.replace("\\", "\\\\"))
+    print("Replacing {} with {}".format(
+        replace_str, formatted_str))
+
+    with open(file_path, "r") as f:
+        new_text: str = f.read().replace(replace_str, formatted_str)
+
+    with open(file_path, "w") as f:
+        f.write(new_text)
+
+
+def create_venv(current_platform: str) -> None:
+    venv_path: str = path.join(path.dirname(__file__), "venv")
+    if not path.exists(venv_path):
+        venv.create(venv_path, with_pip=True)
+        if not path.exists(venv_path):
+            raise RuntimeError(
+                "Unable to create venv at path {}".format(venv_path))
+
+    pip_bin: str = "{}/bin/pip"
+    activate_command: str = "source venv/bin/activate"
+    if current_platform == "windows":
+        pip_bin = "{}/Scripts/pip.exe"
+        activate_command = "source venv/Scripts/activate"
+
+    run("{} install -r requirements.txt".format(pip_bin.format(venv_path)), check=True)
+
+    print("\n++++++\nPlease activate the venv before building GDMP by running `{}`\n++++++\n".format(activate_command))
+
+
+if __name__ == "__main__":
+    parser = ArgumentParser()
+
+    # Extension generation
+    parser.add_argument(
+        "--extension-api-json", required=False, help="Path to a pre-generated extension_api.json file")
+    parser.add_argument("--godot-binary", default="godot",
+                        help="Path to the Godot editor binary. Defaults to user's PATH if not set. Required if --api-json is not set")
+
+    # Platform specific
+    if current_platform == "windows":
+        parser.add_argument("--custom-opencv-dir", required=False,
+                            help="Path to custom OpenCV directory in either Linux or Windows path format. The path will be automatically converted")
+        parser.add_argument("--custom-opencv-version", default=DEFAULT_OPENCV_VERSION,
+                            help="Version of OpenCV to use. Defaults to {}".format(DEFAULT_OPENCV_VERSION))
+
+        def symlinker(src_dir, dst_dir):
+            run('mklink /J "%s" "%s"' %
+                (dst_dir, src_dir), check=True, shell=True)
+    else:  # Linux/MacOS should work roughly the same
+        def symlinker(src_dir, dst_dir):
+            symlink(src_dir, dst_dir, True)
+
+    args: Namespace = parser.parse_args()
+
+    api_json_path: str = args.extension_api_json
+    if not args.extension_api_json:
+        run("{} --dump-extension-api".format(args.godot_binary), check=True)
+        api_json_path = path.join(path.dirname(__file__), "extension_api.json")
+
+    generate_bindings(api_json_path)
+
+    patch_and_symlink(symlinker)
+
+    if current_platform == "windows":
+        if args.custom_opencv_dir:
+            modify_file(MEDIAPIPE_WORKSPACE_PATH, DEFAULT_OPENCV_INSTALL_PATH_REPLACE, OPENCV_INSTALL_PATH_FORMAT,
+                        os.path.abspath(os.path.expanduser(args.custom_opencv_dir)))
+        if args.custom_opencv_version and args.custom_opencv_version != DEFAULT_OPENCV_VERSION:
+            modify_file(OPENCV_BUILD_PATH, DEFAULT_OPENCV_VERSION_REPLACE,
+                        OPENCV_VERSION_FORMAT, args.custom_opencv_version.replace(".", ""))
+
+    create_venv(current_platform)


### PR DESCRIPTION
Made `setup.py` more of an all-in-one script that handles godot-cpp code gen, python venv creation + requirements installation, and auto patching opencv requirements for Windows.

* add .gitignore
* fix typo in README.md
* use argparse to make setup.py configurable
* handle extension_api.json generation in setup.py
* handle opencv replacements in setup.py
* handle virtual env creation
* add requirements.txt

I am starting to look into implementing the new [mediapipe tasks](https://github.com/google/mediapipe/tree/master/mediapipe/tasks) api, so I figured I'd start submitting PRs as I go along.