### PR TITLE
fix building on windows

### DIFF
--- a/GDMP/gpu/gpu_helper.cc
+++ b/GDMP/gpu/gpu_helper.cc
@@ -9,6 +9,7 @@
 #include "mediapipe/objc/util.h"
 #endif
 
+#if !MEDIAPIPE_DISABLE_GPU
 mediapipe::GpuBuffer MediaPipeGPUHelper::get_gpu_buffer(mediapipe::Image image) {
 	mediapipe::GpuBuffer gpu_buffer;
 #if MEDIAPIPE_GPU_BUFFER_USE_CV_PIXEL_BUFFER
@@ -21,6 +22,7 @@ mediapipe::GpuBuffer MediaPipeGPUHelper::get_gpu_buffer(mediapipe::Image image) 
 #endif
 	return gpu_buffer;
 }
+#endif
 
 void MediaPipeGPUHelper::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("initialize", "gpu_resources"), &MediaPipeGPUHelper::initialize);

--- a/build.py
+++ b/build.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 import sys
 from argparse import ArgumentParser
@@ -26,7 +26,9 @@ def get_build_args(target):
                 '--copt', '-fPIC',
             ],
             'win32': [
-                '--define', 'MEDIAPIPE_DISABLE_GPU=1'
+                '--define', 'MEDIAPIPE_DISABLE_GPU=1',
+                '--copt', '-DTYPED_METHOD_BIND',
+                '--copt', '-DNOMINMAX'
             ],
         },
         'android': [


### PR DESCRIPTION
Is there a specific version of godot-cpp that should be used? I was using tag godot-4.0.3-stable but it appears submodule tag also works after a `bazel clean`.

I initially changed some params from `String <param name>` to `const String &<param name>` but that does not seem necessary anymore.

It appears that the `/vmg` flag was necessary for compiling on Windows. [source](https://stackoverflow.com/questions/13875786/pointers-to-members-representations)