### PR TITLE
add manual workflow builds for linux and windows

### DIFF
--- a/.github/download_godot.py
+++ b/.github/download_godot.py
@@ -1,0 +1,44 @@
+import os
+import urllib.request
+import zipfile
+import argparse
+
+# https://stackoverflow.com/questions/6861323/download-and-unzip-file-with-python
+
+DOWNLOAD_URL = "https://github.com/godotengine/godot/releases/download/{version}-stable/Godot_v{version}-stable_{os}.{arch}.zip"
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--current-os", help="The GitHub action runner being used.", required=True)
+    parser.add_argument(
+        "--godot-version", help="The version of Godot to download.", required=True)
+
+    args = parser.parse_args()
+
+    current_os = args.current_os
+    current_arch = ""
+    if current_os == "windows-latest":
+        current_os = "win64"
+        current_arch = "exe"
+    elif current_os == "ubuntu-latest":
+        current_os = "linux"
+        current_arch = "x86_64"
+    elif current_os == "macos-latest":
+        import sys
+        sys.exit(-1)  # Not supported for now
+
+    dl_url = DOWNLOAD_URL.format(
+        version=args.godot_version, os=current_os, arch=current_arch)
+
+    filehandle, _ = urllib.request.urlretrieve(dl_url)
+    zip_file_object = zipfile.ZipFile(filehandle, "r")
+    first_file = zip_file_object.namelist()[0]
+    file = zip_file_object.open(first_file)
+
+    with open("godot", "wb") as f:
+        f.write(file.read())
+
+    if current_os == "linux":
+        os.chmod("godot", 0o777)

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -41,14 +41,16 @@ jobs:
       - name: Install deps Windows
         if: matrix.os == 'windows-latest'
         shell: bash
-        run: choco install opencv --version 3.4.10
+        run: |
+          choco install opencv --version 3.4.10
+          choco install visualstudio2019buildtools
 
       - name: Install deps Ubuntu
         if: matrix.os == 'ubuntu-latest'
         shell: bash
         run: |
           sudo apt-get update
-          sudo apt-get install libopencv-dev libopencv-core-dev libopencv-highgui-dev libopencv-calib3d-dev libopencv-features2d-dev libopencv-imgproc-dev libopencv-video-dev ffmpeg libegl1-mesa-dev -y
+          sudo apt-get install -y libopencv-dev libopencv-core-dev libopencv-highgui-dev libopencv-calib3d-dev libopencv-features2d-dev libopencv-imgproc-dev libopencv-video-dev libopencv-contrib-dev ffmpeg libegl1-mesa-dev
 
       # - name: Install OpenCV Mac
       #   if: matrix.os == 'macos-latest'
@@ -70,7 +72,7 @@ jobs:
         shell: bash
         run: |
           source ./venv/Scripts/activate
-          BAZEL_LLVM=/c/tools/llvm/bin BAZEL_VC=/c/Program\ Files/Microsoft\ Visual\ Studio/2022/Enterprise/VC python build.py desktop
+          BAZEL_LLVM=/c/tools/llvm/bin BAZEL_VC=/c/Program\ Files/Microsoft\ Visual\ Studio/2019/Community/VC python build.py desktop
 
       - name: Build GDMP Unix
         if: matrix.os != 'windows-latest'

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -48,7 +48,7 @@ jobs:
         shell: bash
         run: |
           sudo apt-get update
-          sudo apt-get install libopencv-core-dev libopencv-highgui-dev libopencv-calib3d-dev libopencv-features2d-dev libopencv-imgproc-dev libopencv-video-dev ffmpeg libegl1-mesa-dev
+          sudo apt-get install libopencv-dev libopencv-core-dev libopencv-highgui-dev libopencv-calib3d-dev libopencv-features2d-dev libopencv-imgproc-dev libopencv-video-dev ffmpeg libegl1-mesa-dev -y
 
       # - name: Install OpenCV Mac
       #   if: matrix.os == 'macos-latest'
@@ -70,7 +70,7 @@ jobs:
         shell: bash
         run: |
           source ./venv/Scripts/activate
-          BAZEL_LLVM=/c/tools/llvm/bin python build.py desktop
+          BAZEL_LLVM=/c/tools/llvm/bin BAZEL_VC=/c/Program\ Files/Microsoft\ Visual\ Studio/2022/Enterprise/VC python build.py desktop
 
       - name: Build GDMP Unix
         if: matrix.os != 'windows-latest'

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,117 @@
+---
+name: Build GDMP
+on:
+  workflow_dispatch:
+    inputs:
+      godot_version:
+        type: string
+        description: The major.minor.patch version in major.minor.patch format.
+        required: true
+      ref:
+        type: string
+        description: The branch or tag to checkout.
+        default: ''
+
+jobs:
+  build-gdmp:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [windows-latest, ubuntu-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v3
+        with:
+          submodules: recursive
+          ref: ${{ inputs.ref }}
+      
+      - name: Try to restore Godot from cache
+        id: cached-godot
+        uses: actions/cache@v3
+        with:
+          path: ~/godot
+          key: ${{ matrix.os }}-godot-${{ inputs.godot_version }}
+
+      - name: Download and unzip Godot
+        if: ${{ steps.cached-godot.outputs.cache-hit != 'true' }}
+        shell: bash
+        run: python .github/download_godot.py --current-os ${{ matrix.os }} --godot-version ${{ inputs.godot_version }}
+
+      - name: Install deps Windows
+        if: matrix.os == 'windows-latest'
+        shell: bash
+        run: |
+          choco install opencv --version 3.4.10
+          choco install llvm
+
+      - name: Install deps Ubuntu
+        if: matrix.os == 'ubuntu-latest'
+        shell: bash
+        run: |
+          sudo apt-get update
+          sudo apt-get install libopencv-core-dev libopencv-highgui-dev libopencv-calib3d-dev libopencv-features2d-dev libopencv-imgproc-dev libopencv-video-dev ffmpeg libegl1-mesa-dev
+
+      # - name: Install OpenCV Mac
+      #   if: matrix.os == 'macos-latest'
+      #   shell: bash
+      #   run: brew install opencv
+
+      - name: Run setup.py for Windows
+        if: matrix.os == 'windows-latest'
+        shell: bash
+        run: python setup.py --godot-binary ./godot --custom-opencv-dir C:\\tools\\opencv\\build
+
+      - name: Run setup.py for Unix
+        if: matrix.os != 'windows-latest'
+        shell: bash
+        run: python setup.py --godot-binary ./godot
+
+      - name: Build GDMP Windows
+        if: matrix.os == 'windows-latest'
+        shell: bash
+        run: |
+          source ./venv/Scripts/activate
+          BAZEL_LLVM=/c/tools/llvm/bin python build.py desktop
+
+      - name: Build GDMP Unix
+        if: matrix.os != 'windows-latest'
+        shell: bash
+        run: |
+          source ./venv/bin/activate
+          python build.py desktop
+
+      - name: Set tar name
+        shell: bash
+        run: echo "PROJECT_TAR_NAME=gdmp_${{ matrix.os }}.tar.gz" >> $GITHUB_ENV
+
+      - name: Pack into tar.gz
+        if: matrix.os == 'windows-latest'
+        shell: bash
+        run: |
+          mkdir -p addons/GDMP/lib/x86_64/
+          cp mediapipe/bazel-bin/GDMP/desktop/*.dll addons/GDMP/lib/x86_64/
+          tar -czvf ${{ env.PROJECT_TAR_NAME }} addons
+      
+      - name: Pack into tar.gz
+        if: matrix.os == 'ubuntu-latest'
+        shell: bash
+        run: |
+          mkdir -p addons/GDMP/lib/x86_64/
+          cp mediapipe/bazel-bin/GDMP/desktop/*.so addons/GDMP/lib/x86_64/
+          tar -czvf ${{ env.PROJECT_TAR_NAME }} addons
+      
+      # - name: Pack into tar.gz
+      #   if: matrix.os == 'macos'
+      #   shell: bash
+      #   run: |
+      #     mkdir -p addons/GDMP/lib/x86_64/
+      #     cp mediapipe/bazel-bin/GDMP/desktop/*.dylib addons/GDMP/lib/x86_64/
+      #     tar -czvf ${{ env.PROJECT_TAR_NAME }} addons
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ env.PROJECT_TAR_NAME }}
+          path: |
+            ${{ env.PROJECT_TAR_NAME }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -41,9 +41,7 @@ jobs:
       - name: Install deps Windows
         if: matrix.os == 'windows-latest'
         shell: bash
-        run: |
-          choco install opencv --version 3.4.10
-          choco install llvm
+        run: choco install opencv --version 3.4.10
 
       - name: Install deps Ubuntu
         if: matrix.os == 'ubuntu-latest'

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -50,7 +50,11 @@ jobs:
         shell: bash
         run: |
           sudo apt-get update
-          sudo apt-get install -y libopencv-dev libopencv-core-dev libopencv-highgui-dev libopencv-calib3d-dev libopencv-features2d-dev libopencv-imgproc-dev libopencv-video-dev libopencv-contrib-dev ffmpeg libegl1-mesa-dev
+          sudo apt-get install -y ffmpeg libegl1-mesa-dev
+          
+          # Installing deps from the default repos doesn't appear to work in GitHub actions
+          chmod +x mediapipe/setup_opencv.sh
+          ./mediapipe/setup_opencv.sh
 
       # - name: Install OpenCV Mac
       #   if: matrix.os == 'macos-latest'
@@ -72,7 +76,7 @@ jobs:
         shell: bash
         run: |
           source ./venv/Scripts/activate
-          BAZEL_LLVM=/c/tools/llvm/bin BAZEL_VC=/c/Program\ Files/Microsoft\ Visual\ Studio/2019/Community/VC python build.py desktop
+          BAZEL_LLVM=/c/tools/llvm/bin BAZEL_VC=/c/Program\ Files\ \(x86\)/Microsoft\ Visual\ Studio/2019/Community/VC python build.py desktop
 
       - name: Build GDMP Unix
         if: matrix.os != 'windows-latest'


### PR DESCRIPTION
~~Testing for the workflow is happening in [this separate repo](https://github.com/you-win/gdmp-workflow-test). A separate repo is being used since I find it easier to test new workflows like that.~~ Moved to [my fork](https://github.com/you-win/GDMP/actions/workflows/build.yaml) for final testing.

The idea is that precompiled binaries for Linux and Windows can be built using GitHub's hosted runners. For now, artifacts will just be uploaded as workload artifacts, but this can be configured to also create new releases.

Todos

* [ ] [cache](https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows) godot binary between runs and also maybe opencv on Windows targets
* [ ] fix building on windows, it looks like the opencv path that's being used is wrong
* [ ] verify uploading build artifacts works correctly