### PR TITLE
Add CI build workflow

### DIFF
--- a/.github/workflows/build_addon.yml
+++ b/.github/workflows/build_addon.yml
@@ -1,0 +1,248 @@
+name: Build Addon
+
+on: [push, pull_request]
+
+jobs:
+  # Build the Windows Artifacts
+  build-windows:
+    name: 🏁 Build Windows
+    runs-on: windows-2019
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.9"
+
+      - name: Setup Bazelisk
+        uses: bazelbuild/setup-bazelisk@v3
+
+      - name: Prerequisites
+        shell: bash
+        run: |
+          choco install visualstudio2019buildtools visualstudio2019-workload-vctools
+          choco install opencv --version 3.4.10
+
+      - name: Setup
+        shell: bash
+        run: |
+          python ./setup.py --custom-opencv-dir C:/tools/opencv/build
+
+      - name: Build
+        env:
+          BAZEL_VC: "C:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\BuildTools\\VC"
+        shell: bash
+        run: |
+          source ./venv/Scripts/activate
+          python ./build.py desktop --type release
+
+      - name: Upload build files (artifacts)
+        uses: actions/upload-artifact@v4
+        with:
+          name: build-artifact-windows
+          path: |
+            mediapipe/bazel-bin/GDMP/desktop/*.dll
+
+
+  # Build the Linux Artifacts
+  build-linux:
+    name: 🐧 Build Linux
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.9"
+
+      - name: Setup Bazelisk
+        uses: bazelbuild/setup-bazelisk@v3
+
+      - name: Prerequisites
+        run: |
+          sudo apt-get install -y \
+            ffmpeg \
+            libegl1-mesa-dev \
+            libopencv-core-dev \
+            libopencv-highgui-dev \
+            libopencv-calib3d-dev \
+            libopencv-features2d-dev \
+            libopencv-imgproc-dev \
+            libopencv-video-dev \
+            libopencv-contrib-dev
+          sed -i 's/#"include\/opencv4/"include\/opencv4/g' mediapipe/third_party/opencv_linux.BUILD
+
+      - name: Setup
+        run: |
+          python ./setup.py
+
+      - name: Build
+        run: |
+          source ./venv/bin/activate
+          python ./build.py desktop --type release
+
+      - name: Upload build files (artifacts)
+        uses: actions/upload-artifact@v4
+        with:
+          name: build-artifact-linux
+          path: |
+            mediapipe/bazel-bin/GDMP/desktop/*.so
+
+
+  # Build the Android Artifacts
+  build-android:
+    name: 🤖 Build Android
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Free Disk Space
+        uses: jlumbroso/free-disk-space@v1.3.1
+        with:
+          android: false
+
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+          cache: 'gradle'
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.9"
+
+      - name: Setup Bazelisk
+        uses: bazelbuild/setup-bazelisk@v3
+
+      - name: Setup Android NDK
+        id: setup-ndk
+        uses: nttld/setup-ndk@v1
+        with:
+          ndk-version: r21e
+          link-to-sdk: true
+
+      - name: Setup Gradle 7.4.2
+        uses: gradle/actions/setup-gradle@v3
+        with:
+          gradle-version: 7.4.2
+
+      - name: Setup
+        run: |
+          python ./setup.py
+
+      - name: Android SDK/NDK Patch
+        run: |
+          echo "android_sdk_repository(name = \"androidsdk\")" >> mediapipe/WORKSPACE
+          echo "android_ndk_repository(name = \"androidndk\", api_level=21)" >> mediapipe/WORKSPACE
+
+      - name: Build
+        env:
+          ANDROID_NDK_HOME: ${{ steps.setup-ndk.outputs.ndk-path }}
+        run: |
+          source ./venv/bin/activate
+          python ./build.py android --arch arm64-v8a --type release << EOL
+          y
+          y
+          n
+          EOL
+
+      - name: Gradle Build
+        env:
+          ANDROID_NDK_HOME: ${{ steps.setup-ndk.outputs.ndk-path }}
+        working-directory: ./android
+        run: |
+          gradle clean assembleRelease
+
+      - name: Upload build files (artifacts)
+        uses: actions/upload-artifact@v4
+        with:
+          name: build-artifact-android
+          path: |
+            android/build/outputs/aar/*.aar
+
+
+  # Build the iOS Artifacts
+  build-ios:
+    name: 🍏 Build iOS
+    runs-on: macos-13
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.9"
+
+      - name: Setup Bazelisk
+        uses: bazelbuild/setup-bazelisk@v3
+
+      - name: Setup
+        run: |
+          python ./setup.py
+
+      - name: Build
+        run: |
+          source ./venv/bin/activate
+          python ./build.py ios --type release
+
+      - name: Upload build files (artifacts)
+        uses: actions/upload-artifact@v4
+        with:
+          name: build-artifact-ios
+          path: |
+            mediapipe/bazel-bin/GDMP/ios/GDMP.zip
+
+
+  # Assemble the Addon
+  assemble-addon:
+    name: Assemble Addon
+    runs-on: ubuntu-22.04
+    needs: [build-windows, build-linux, build-android, build-ios]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Download all workflow run artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: build-artifact-*
+
+      - name: Populate Addon
+        run: |
+          cp LICENSE addons/GDMP/
+          cp README.md addons/GDMP/
+          mkdir -p addons/GDMP/libs/x86_64/
+          cp build-artifact-windows/*.dll addons/GDMP/libs/x86_64/
+          cp build-artifact-linux/*.so addons/GDMP/libs/x86_64/
+          cp build-artifact-android/*.aar addons/GDMP/libs
+          unzip -o build-artifact-ios/GDMP.zip -d addons/GDMP/libs
+
+      - name: Patch GDMP.gdextension
+        run: |
+          sed -i 's/libGDMP\..*\.so/libGDMP.so/g' addons/GDMP/GDMP.gdextension
+          sed -i 's/GDMP\..*\.dll/GDMP.dll/g' addons/GDMP/GDMP.gdextension
+          sed -i 's/GDMP\..*\.framework/GDMP.ios.release.framework/g' addons/GDMP/GDMP.gdextension
+          sed -i 's/opencv_world3410d/opencv_world3410/g' addons/GDMP/GDMP.gdextension
+
+      - name: Create Addon Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: Addon
+          path: |
+            addons

--- a/setup.py
+++ b/setup.py
@@ -46,6 +46,7 @@ else:  # Linux/MacOS should work roughly the same
 
 def generate_bindings(api_json_path: str) -> None:
     # Could use a contextmanager but that feels like overkill
+    oldcwd = os.getcwd()
     os.chdir(GODOT_CPP_DIR)
     sys.path.append(os.getcwd())
 
@@ -54,6 +55,7 @@ def generate_bindings(api_json_path: str) -> None:
     bg.generate_bindings(api_json_path, True)
 
     sys.path.pop()
+    os.chdir(oldcwd)
 
 
 def patch_and_symlink() -> None:


### PR DESCRIPTION
This PR adds a CI build workflow which assembles:
* The Windows x86_64 release build
* The Linux x86_64 release build
* The Android aarch64 release build
* The iOS release build
* The GDMP Asset package (with libraries, license, and readme)

It did require a fix to the `generate_bindings` function in setup.py to restore the working directory after generating the bindings.
