### PR TITLE
Update mediapipe to 0.10.13

### DIFF
--- a/mediapipe_setup.diff
+++ b/mediapipe_setup.diff
@@ -22,3 +22,44 @@ diff --git a/WORKSPACE b/WORKSPACE
  # Protobuf expects an //external:python_headers target
  bind(
      name = "python_headers",
+diff --git a/third_party/flatbuffers/workspace.bzl b/third_party/flatbuffers/workspace.bzl
+--- a/third_party/flatbuffers/workspace.bzl
++++ b/third_party/flatbuffers/workspace.bzl
+@@ -5,11 +5,11 @@ load("//third_party:repo.bzl", "third_party_http_archive")
+ def repo():
+     third_party_http_archive(
+         name = "flatbuffers",
+-        strip_prefix = "flatbuffers-23.5.26",
+-        sha256 = "1cce06b17cddd896b6d73cc047e36a254fb8df4d7ea18a46acf16c4c0cd3f3f3",
++        strip_prefix = "flatbuffers-6ff9e90e7e399f3977e99a315856b57c8afe5b4d",
++        sha256 = "f4b3dfed9f8f4f0fd9f857fe96a46199cb5745ddb458cad20caf6837230ea188",
+         urls = [
+-            "https://github.com/google/flatbuffers/archive/v23.5.26.tar.gz",
+-            "https://github.com/google/flatbuffers/archive/v23.5.26.tar.gz",
++            "https://github.com/google/flatbuffers/archive/6ff9e90e7e399f3977e99a315856b57c8afe5b4d.tar.gz",
++            "https://github.com/google/flatbuffers/archive/6ff9e90e7e399f3977e99a315856b57c8afe5b4d.tar.gz",
+         ],
+         build_file = "//third_party/flatbuffers:BUILD.bazel",
+         delete = ["build_defs.bzl", "BUILD.bazel"],
+diff --git a/mediapipe/tasks/cc/core/task_api_factory.h b/mediapipe/tasks/cc/core/task_api_factory.h
+--- a/mediapipe/tasks/cc/core/task_api_factory.h
++++ b/mediapipe/tasks/cc/core/task_api_factory.h
+@@ -76,15 +76,17 @@ class TaskApiFactory {
+         found_task_subgraph = true;
+       }
+     }
++#if !MEDIAPIPE_DISABLE_GPU
+     MP_ASSIGN_OR_RETURN(
+         auto runner,
+-#if !MEDIAPIPE_DISABLE_GPU
+         core::TaskRunner::Create(std::move(graph_config), std::move(resolver),
+                                  std::move(packets_callback),
+                                  std::move(default_executor),
+                                  std::move(input_side_packets),
+                                  /*resources=*/nullptr, std::move(error_fn)));
+ #else
++    MP_ASSIGN_OR_RETURN(
++        auto runner,
+         core::TaskRunner::Create(
+             std::move(graph_config), std::move(resolver),
+             std::move(packets_callback), std::move(default_executor),


### PR DESCRIPTION
This PR updates mediapipe to 0.10.13 and uses `mediapipe_setup.diff` to apply the following additional patches:
- Flatbuffers upgrade to 24.3.7
- Remove preprocessor directives in function-like macros